### PR TITLE
Fix macOS Sonoma Ruler View bug

### DIFF
--- a/Sources/SavannaKit/Util/NSMutableAttributedString+Tokens.swift
+++ b/Sources/SavannaKit/Util/NSMutableAttributedString+Tokens.swift
@@ -16,8 +16,7 @@ import Foundation
 
 public extension NSMutableAttributedString {
 	
-	convenience public init(source: String, tokens: [Token], theme: SyntaxColorTheme) {
-		
+    convenience init(source: String, tokens: [Token], theme: SyntaxColorTheme) {
 		self.init(string: source)
 		
 		var attributes = [NSAttributedString.Key: Any]()
@@ -47,7 +46,6 @@ public extension NSMutableAttributedString {
 		self.setAttributes(attributes, range: wholeRange)
 		
 		for token in tokens {
-			
 			if token.isPlain {
 				continue
 			}
@@ -75,9 +73,7 @@ public extension NSMutableAttributedString {
 //			}
 			
 			self.setAttributes(theme.attributes(for: token), range: tokenRange)
-			
 		}
-		
 	}
 	
 }

--- a/Sources/SavannaKit/View/InnerTextView+MultilineEditing.swift
+++ b/Sources/SavannaKit/View/InnerTextView+MultilineEditing.swift
@@ -223,9 +223,7 @@ extension InnerTextView {
         }
         
         return selectionRanges.compactMap({ range in
-            guard range.length == 0 else {
-                return nil
-            }
+            guard range.length == 0 else { return nil }
             
             // use previous character rect for cursor position
             var location = range.location
@@ -239,7 +237,7 @@ extension InnerTextView {
             let rect = getCharacterRect(at: location)
             var origin = rect.origin
             
-            if(isLastChar) {
+            if isLastChar {
                 origin = NSPoint(x: origin.x + rect.width, y: origin.y)
             }
             
@@ -247,7 +245,6 @@ extension InnerTextView {
             // thought saying I cared about "Pixel perfection" was cool.
             // I mean caring is cool, but saying it is very much  not.
             origin = NSPoint(x: round(origin.x) - 1, y: origin.y)
-            
             
             return NSRect(origin: origin, size: NSSize(width: 1, height: rect.height))
         })
@@ -344,10 +341,8 @@ extension InnerTextView {
         
     }
     
-    
     func setSelectionRanges(_ ranges: [NSRange]) {
         self.insertionRanges = ranges
-        
         self.selectedRanges = ranges.filter { $0.length > 0 } as [NSValue]
     }
     
@@ -361,21 +356,19 @@ extension InnerTextView {
                 return position
             }
             return self.move(position, direction, by: 1)
-        }.map { NSRange(location: $0, length: 0) }
+        }
+        .map {
+            NSRange(location: $0, length: 0)
+        }
     }
     
     // this is peak function signature fight me
     // move(index, .up, by: 1)
     func move(_ index: Int, _ direction: MoveDirection, by: Int) -> Int? {
-        guard
-            let textStorage = self.textStorage
-        else {
-            return nil
-        }
+        guard let textStorage = self.textStorage else { return nil }
         
         let lineRange = self.getLineRange(for: index)
         let characterPosition = index - lineRange.location
-        
         
         switch direction {
         case .up:
@@ -386,9 +379,7 @@ extension InnerTextView {
             }
             
             let previousLineRange = self.getLineRange(for: previousLine)
-            
             return previousLineRange.lowerBound + min(previousLineRange.length, characterPosition)
-            
         case .down:
             let nextLine = lineRange.upperBound + 1
             guard nextLine < textStorage.length else {
@@ -399,7 +390,6 @@ extension InnerTextView {
             let nextLineRange = self.getLineRange(for: nextLine)
             
             return nextLineRange.lowerBound + min(nextLineRange.length, characterPosition)
-            
         case .left:
             guard index - 1 >= 0 else {
                 // out of bounds, let's return 0 like Xcode does
@@ -424,7 +414,6 @@ extension InnerTextView {
     }
     
     func getLineInfo(for glyphIndex: Int) -> (NSRange, NSRect) {
-        
         guard let layoutManager = layoutManager else {
             fatalError("Missing Layout Manager. How did we get so far without it??")
         }
@@ -451,7 +440,6 @@ extension InnerTextView {
             return self.selectedRanges = [NSValue()]
         }
         self.selectedRanges = selection
-        
     }
     
 }

--- a/Sources/SavannaKit/View/InnerTextView.swift
+++ b/Sources/SavannaKit/View/InnerTextView.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2017 Silver Fox. All rights reserved.
 //
 
-import Foundation
-import CoreGraphics
 import AppKit
 import Carbon.HIToolbox
+import CoreGraphics
+import Foundation
 
 protocol InnerTextViewDelegate: class {
 	func didUpdateCursorFloatingState()
@@ -72,26 +72,18 @@ public final class InnerTextView: NSTextView {
         // TODO: Handle this
     }
     
-    
     public override func insertText(_ string: Any, replacementRange: NSRange) {
         switch string as? String {
-           case "[":
-               insertAfter(string, "]")
-           case "{":
-               insertAfter(string, "}")
-           case "(":
-               insertAfter(string, ")")
-           case "\"":
-               insertQuotes(string, "\"")
-           case "'":
-               insertQuotes(string, "'")
-           default:
-               super.insertText(string, replacementRange: replacementRange)
+           case "[": insertAfter(string, "]")
+           case "{": insertAfter(string, "}")
+           case "(": insertAfter(string, ")")
+           case "\"": insertQuotes(string, "\"")
+           case "'": insertQuotes(string, "'")
+           default: super.insertText(string, replacementRange: replacementRange)
            }
     }
     
     private func insertAfter(_ before: Any, _ after: String) {
-        
         // Skip the second char to avoid duplicates
         var skipAfter = false
         
@@ -103,19 +95,14 @@ public final class InnerTextView: NSTextView {
             }
         }
         
-        
         super.insertText(before, replacementRange: self.selectedRange)
         
-        guard !skipAfter else {
-            return
-        }
-        
+        guard !skipAfter else { return }
         super.insertText(after, replacementRange: self.selectedRange)
         self.moveBackward(self)
     }
     
     private func insertQuotes(_ before: Any, _ after: String) {
-        
         guard self.selectedRange.length > 0 else {
             insertAfter(before, after)
             return
@@ -126,26 +113,21 @@ public final class InnerTextView: NSTextView {
         targetRange.length = 0
         
         super.insertText(before, replacementRange: targetRange)
-        
         targetRange.location = originalRange.upperBound + 1
         
         super.insertText(after, replacementRange: targetRange)
-        
         originalRange.location += 1
         
         self.setSelectedRange(originalRange)
     }
 	
     public override func insertTab(_ sender: Any?) {
-        
         self.undoManager?.beginUndoGrouping()
         
-        var range = self.selectedRange
-        
+        let range = self.selectedRange
         let spaces = String(repeating: " ", count: theme?.tabWidth ?? 4)
         
         super.insertText(spaces, replacementRange: range)
-        
         self.undoManager?.endUndoGrouping()
         
         // TODO: Add selection tabbing support
@@ -171,4 +153,5 @@ public final class InnerTextView: NSTextView {
     public override var readablePasteboardTypes: [NSPasteboard.PasteboardType] {
         return [.string]
     }
+    
 }

--- a/Sources/SavannaKit/View/LineRulerView.swift
+++ b/Sources/SavannaKit/View/LineRulerView.swift
@@ -6,20 +6,20 @@
 //  Copyright © 2019 Silver Fox. All rights reserved.
 //
 
-import Foundation
 import AppKit
+import Foundation
 
 class LineRulerView: NSRulerView {
-    
     
     var textView: InnerTextView?
     
     init(textView: InnerTextView) {
         self.textView = textView
-        super.init(scrollView: textView.enclosingScrollView!, orientation: NSRulerView.Orientation.verticalRuler)
-      
+        super.init(
+            scrollView: textView.enclosingScrollView!,
+            orientation: NSRulerView.Orientation.verticalRuler
+        )
         self.clientView = textView
-        
     }
     
     required init(coder: NSCoder) {
@@ -27,70 +27,79 @@ class LineRulerView: NSRulerView {
     }
     
     override func drawHashMarksAndLabels(in rect: NSRect) {
-        guard let textView = textView, let theme = textView.theme else {
-            return
-        }
+        guard let textView = textView,
+              let theme = textView.theme
+        else { return }
+        
+        // As of, at least, macOS Sonomoa (14.0) the NSRect provided in the parameter here
+        // is equal to the full width of its parent view. To workaround this change in the
+        // provided values, we need to update the width to fixed value, and then later map
+        // the width to the expected rule thickness.
+        //
+        let sonomaResolvedRect = NSRect(
+            x: rect.origin.x,
+            y: rect.origin.y,
+            width: 40,
+            height: rect.size.height
+        )
         
         theme.gutterStyle.backgroundColor.setFill()
         
-        guard
-            theme.lineNumbersStyle != nil
-            else {
-                let path = BezierPath(rect: rect)
-                path.fill()
-                return
+        guard theme.lineNumbersStyle != nil else {
+            let path = BezierPath(rect: sonomaResolvedRect)
+            path.fill()
+            return
         }
         
-        
         let contentHeight = textView.enclosingScrollView!.documentView!.bounds.height
-        
         let yOffset = self.bounds.height - contentHeight
-        
         var paragraphs: [Paragraph]
         
         if let cached = textView.cachedParagraphs {
-            
             paragraphs = cached
-            
         } else {
-            
             paragraphs = generateParagraphs(for: textView, flipRects: false)
             textView.cachedParagraphs = paragraphs
-            
         }
         
         paragraphs = offsetParagraphs(paragraphs, for: textView, yOffset: yOffset)
         
         let components = textView.text.components(separatedBy: .newlines)
-        
         let count = components.count
-        
         let maxNumberOfDigits = "\(count)".count
         
         let leftInset: CGFloat = 10.0
         let rightInset: CGFloat = 8.0
-        
         let charWidth: CGFloat = 10.0
         
         // Stretch to fit the largest number
-        self.ruleThickness = max(theme.gutterStyle.minimumWidth , CGFloat(maxNumberOfDigits) * charWidth + leftInset + rightInset)
+        self.ruleThickness = max(
+            theme.gutterStyle.minimumWidth ,
+            CGFloat(maxNumberOfDigits) * charWidth + leftInset + rightInset
+        )
         
-   
         theme.gutterStyle.backgroundColor.setFill()
-    
-        let path = BezierPath(rect: rect)
+        
+        // See comment above about the rect param on macOS Sonoma.
+        //
+        let thickenedRect = NSRect(
+            origin: sonomaResolvedRect.origin,
+            size: CGSize(width: ruleThickness, height: sonomaResolvedRect.height)
+        )
+        let path = BezierPath(rect: thickenedRect)
         path.fill()
         
         if let separatorColor = theme.gutterStyle.separatorColor {
             separatorColor.setStroke()
             
             let separator = NSBezierPath()
-            separator.move(to: CGPoint(x: rect.maxX, y: rect.minY))
-            separator.line(to: CGPoint(x: rect.maxX, y: rect.maxY))
+            separator.move(to: CGPoint(x: thickenedRect.maxX, y: thickenedRect.minY))
+            separator.line(to: CGPoint(x: thickenedRect.maxX, y: thickenedRect.maxY))
             separator.lineWidth = 2
             separator.stroke()
         }
         
-        drawLineNumbers(paragraphs, in: rect, for: textView)
+        drawLineNumbers(paragraphs, in: thickenedRect, for: textView)
     }
+    
 }

--- a/Sources/SavannaKit/View/SyntaxTextView.swift
+++ b/Sources/SavannaKit/View/SyntaxTextView.swift
@@ -11,74 +11,78 @@ import CoreGraphics
 import AppKit
 
 public protocol SyntaxTextViewDelegate: AnyObject {
-	
-	func didChangeText(_ syntaxTextView: SyntaxTextView)
-
-	func didChangeSelectedRange(_ syntaxTextView: SyntaxTextView, selectedRange: NSRange)
-	
-	func textViewDidBeginEditing(_ syntaxTextView: SyntaxTextView)
-	
-	func lexerForSource(_ source: String) -> Lexer
+    
+    func didChangeText(_ syntaxTextView: SyntaxTextView)
+    
+    func didChangeSelectedRange(_ syntaxTextView: SyntaxTextView, selectedRange: NSRange)
+    
+    func textViewDidBeginEditing(_ syntaxTextView: SyntaxTextView)
+    
+    func lexerForSource(_ source: String) -> Lexer
     
     func theme(for appearance: NSAppearance) -> SyntaxColorTheme
     
     func didUpdateSelectionRanges(_ syntaxTextView: SyntaxTextView)
+    
 }
 
 // Provide default empty implementations of methods that are optional.
+//
 public extension SyntaxTextViewDelegate {
     
     func didChangeText(_ syntaxTextView: SyntaxTextView) { }
-	
+    
     func didChangeSelectedRange(_ syntaxTextView: SyntaxTextView, selectedRange: NSRange) { }
-	
+    
     func textViewDidBeginEditing(_ syntaxTextView: SyntaxTextView) { }
     
     func didUpdateSelectionRanges(_ syntaxTextView: SyntaxTextView) { }
-
+    
 }
 
 struct ThemeInfo {
-	
-	let theme: SyntaxColorTheme
-	
-	/// Width of a space character in the theme's font.
-	/// Useful for calculating tab indent size.
-	let spaceWidth: CGFloat
-	
+    
+    let theme: SyntaxColorTheme
+    
+    /// Width of a space character in the theme's font.
+    /// 
+    /// Useful for calculating tab indent size.
+    ///
+    let spaceWidth: CGFloat
+    
 }
 
 @IBDesignable
 open class SyntaxTextView: View {
-
-	var previousSelectedRange: NSRange?
-	
-	private var textViewSelectedRangeObserver: NSKeyValueObservation?
-
-	let textView: InnerTextView
+    
+    var previousSelectedRange: NSRange?
+    
+    private var textViewSelectedRangeObserver: NSKeyValueObservation?
+    
+    let textView: InnerTextView
     var rulerView: LineRulerView?
-	
-	public var contentTextView: TextView {
-		return textView
-	}
-	
-	public weak var delegate: SyntaxTextViewDelegate? {
-		didSet {
-			didUpdateText()
+    
+    public var contentTextView: TextView {
+        return textView
+    }
+    
+    public weak var delegate: SyntaxTextViewDelegate? {
+        didSet {
+            didUpdateText()
             self.theme = delegate?.theme(for: self.effectiveAppearance)
-		}
-	}
-	
-	var ignoreSelectionChange = false
-	
-	public var tintColor: NSColor! {
-		set {
-			textView.tintColor = newValue
-		}
-		get {
-			return textView.tintColor
-		}
-	}
+        }
+    }
+    
+    var ignoreSelectionChange = false
+    
+    public var tintColor: NSColor! {
+        set {
+            textView.tintColor = newValue
+        }
+        get {
+            return textView.tintColor
+        }
+    }
     
     public override init(frame: CGRect) {
         textView = SyntaxTextView.createInnerTextView()
@@ -91,36 +95,28 @@ open class SyntaxTextView: View {
         super.init(coder: aDecoder)
         setup()
     }
-	
+    
     private static func createInnerTextView() -> InnerTextView {
         let textStorage = NSTextStorage()
         let layoutManager = SyntaxTextViewLayoutManager()
         let containerSize = CGSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
-				
-        let textContainer = NSTextContainer(size: containerSize)
         
+        let textContainer = NSTextContainer(size: containerSize)
         textContainer.widthTracksTextView = true
-		
+        
         layoutManager.addTextContainer(textContainer)
         textStorage.addLayoutManager(layoutManager)
         
         return InnerTextView(frame: .zero, textContainer: textContainer)
     }
-
-
+    
     public let scrollView = NSScrollView()
-	
-	private func setup() {
-        
-        
-        
+    
+    private func setup() {
         scrollView.backgroundColor = .clear
         scrollView.drawsBackground = false
-        
         scrollView.contentView.backgroundColor = .clear
-        
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-
         addSubview(scrollView)
         
         scrollView.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
@@ -134,11 +130,15 @@ open class SyntaxTextView: View {
         scrollView.scrollerKnobStyle = .light
         
         scrollView.documentView = textView
-    
+        
         scrollView.contentView.postsFrameChangedNotifications = true
         
-        NotificationCenter.default.addObserver(self, selector: #selector(renewLines(_:)), name: NSView.frameDidChangeNotification, object: scrollView.contentView)
-        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(renewLines(_:)),
+            name: NSView.frameDidChangeNotification,
+            object: scrollView.contentView
+        )
         
         textView.minSize = NSSize(width: 0.0, height: self.bounds.height)
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
@@ -151,35 +151,33 @@ open class SyntaxTextView: View {
         textView.allowsUndo = true
         textView.usesFindBar = true
         
-       
-        textView.textContainer?.containerSize = NSSize(width: self.bounds.width, height: .greatestFiniteMagnitude)
+        textView.textContainer?.containerSize = NSSize(width: max(self.bounds.width, 100.0), height: .greatestFiniteMagnitude)
         textView.textContainer?.widthTracksTextView = true
-		
-		textView.innerDelegate = self
-		textView.delegate = self
+        
+        textView.innerDelegate = self
+        textView.delegate = self
         
         if let scrollView = textView.enclosingScrollView {
-            
             rulerView = LineRulerView(textView: textView)
             scrollView.verticalRulerView = rulerView
             scrollView.hasVerticalRuler = true
             scrollView.rulersVisible = true
-            
             scrollView.contentView.postsBoundsChangedNotifications = true
-            
-            NotificationCenter.default.addObserver(self,
+
+            NotificationCenter.default.addObserver(
+                self,
                 selector: #selector(scrollViewDidResize(_:)),
                 name: NSView.boundsDidChangeNotification,
-                object: scrollView.contentView)
+                object: scrollView.contentView
+            )
         }
         
-		textView.text = ""
-	}
+        textView.text = ""
+    }
     
     @objc public func scrollViewDidResize(_ notification: NSNotification) {
         textView.scrollViewDidResize(scrollView)
     }
-
     
     @objc func renewLines(_ notification: Notification) {
         self.textView.invalidateCachedParagraphs()
@@ -189,128 +187,98 @@ open class SyntaxTextView: View {
     @available(OSXApplicationExtension 10.14, *)
     open override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        
         self.theme = delegate?.theme(for: self.effectiveAppearance)
     }
-
-	// MARK: -
-	
-	@IBInspectable
-	public var text: String {
-		get {
+    
+    // MARK: -
+    
+    @IBInspectable
+    public var text: String {
+        get {
             return textView.string
-		}
-		set {
+        }
+        set {
             textView.layer?.isOpaque = true
-
             textView.string = newValue
-            
             self.didUpdateText()
-		}
-	}
-	
-	// MARK: -
-
-
-	public var theme: SyntaxColorTheme? {
-		didSet {
-			
-			guard let theme = theme else {
-				return
-			}
-			
-			cachedThemeInfo = nil
+        }
+    }
+    
+    // MARK: -
+    
+    public var theme: SyntaxColorTheme? {
+        didSet {
+            guard let theme = theme else { return }
+            cachedThemeInfo = nil
             textView.backgroundColor = theme.backgroundColor
             textView.theme = theme
-			textView.font = theme.font
+            textView.font = theme.font
             cachedThemeInfo = nil
-			
-			didUpdateText()
-		}
-	}
-	
-	var cachedThemeInfo: ThemeInfo?
-	
-	var themeInfo: ThemeInfo? {
-		
-		if let cached = cachedThemeInfo {
-			return cached
-		}
-		
-		guard let theme = theme else {
-			return nil
-		}
-		
-		let spaceAttrString = NSAttributedString(string: " ", attributes: [.font: theme.font])
-		let spaceWidth = spaceAttrString.size().width
-		
-		let info = ThemeInfo(theme: theme, spaceWidth: spaceWidth)
-		
-		cachedThemeInfo = info
-		
-		return info
-	}
-	
-	var cachedTokens: [CachedToken]?
-	
-	func invalidateCachedTokens() {
-		cachedTokens = nil
-	}
-	
-	func colorTextView(lexerForSource: (String) -> Lexer) {
-		
-		guard let source = textView.text else {
-			return
-		}
-		
-		let textStorage: NSTextStorage
-				
+            didUpdateText()
+        }
+    }
+    
+    var cachedThemeInfo: ThemeInfo?
+    
+    var themeInfo: ThemeInfo? {
+        if let cached = cachedThemeInfo {
+            return cached
+        }
+        
+        guard let theme = theme else { return nil }
+        
+        let spaceAttrString = NSAttributedString(string: " ", attributes: [.font: theme.font])
+        let spaceWidth = spaceAttrString.size().width
+        
+        let info = ThemeInfo(theme: theme, spaceWidth: spaceWidth)
+        
+        cachedThemeInfo = info
+        
+        return info
+    }
+    
+    var cachedTokens: [CachedToken]?
+    
+    func invalidateCachedTokens() {
+        cachedTokens = nil
+    }
+    
+    func colorTextView(lexerForSource: (String) -> Lexer) {
+        guard let source = textView.text else { return }
+        
+        let textStorage: NSTextStorage
         textStorage = textView.textStorage!
-				
+        
         var tokens: [Token]
-		
-		if let cachedTokens = cachedTokens {
-			
-			updateAttributes(textStorage: textStorage, cachedTokens: cachedTokens, source: source)
-			
-		} else {
-			
-			guard let theme = self.theme else {
-				return
-			}
-			
-			guard let themeInfo = self.themeInfo else {
-				return
-			}
-			
-			textView.font = theme.font
+        
+        if let cachedTokens = cachedTokens {
+            updateAttributes(textStorage: textStorage, cachedTokens: cachedTokens, source: source)
+        } else {
+            guard let theme = self.theme else { return }
+            guard let themeInfo = self.themeInfo else { return }
             
+            textView.font = theme.font
             
-
-			let lexer = lexerForSource(source)
-			tokens = lexer.getSavannaTokens(input: source)
-            
+            let lexer = lexerForSource(source)
+            tokens = lexer.getSavannaTokens(input: source)
             
             toggleTokens(tokens: tokens)
-			
-			let cachedTokens: [CachedToken] = tokens.map {
-
+            
+            let cachedTokens: [CachedToken] = tokens.map {
                 return CachedToken(token: $0, nsRange: $0.range)
-			}
-
-			self.cachedTokens = cachedTokens
-			
-			createAttributes(theme: theme, themeInfo: themeInfo, textStorage: textStorage, cachedTokens: cachedTokens, source: source)
-			
-		}
-		
-	}
+            }
+            
+            self.cachedTokens = cachedTokens
+            
+            createAttributes(theme: theme, themeInfo: themeInfo, textStorage: textStorage, cachedTokens: cachedTokens, source: source)
+        }
+    }
     
     func toggleTokens(tokens: [Token]) {
         let sortedTokens = tokens.sorted { (left, right) -> Bool in
             left.range.lowerBound < right.range.lowerBound
         }
-
+        
         guard let first = sortedTokens.first else {
             // No token found.
             return
@@ -319,12 +287,11 @@ open class SyntaxTextView: View {
         var currentToken = first
         
         var firstLoop = true
-
+        
         for var token in sortedTokens {
-
             if currentToken.isGreedy,
-                currentToken.range.contains(token.range.location),
-                !firstLoop {
+               currentToken.range.contains(token.range.location),
+               !firstLoop {
                 token.isActive = false
             } else {
                 firstLoop = false
@@ -332,135 +299,110 @@ open class SyntaxTextView: View {
             }
         }
     }
-
-	func updateAttributes(textStorage: NSTextStorage, cachedTokens: [CachedToken], source: String) {
-
-		let selectedRange = textView.selectedRange
-		
-		let fullRange = NSRange(location: 0, length: (source as NSString).length)
-		
-		var rangesToUpdate = [(NSRange, EditorPlaceholderState)]()
-		
-		textStorage.enumerateAttribute(.editorPlaceholder, in: fullRange, options: []) { (value, range, stop) in
-			
-			if let state = value as? EditorPlaceholderState {
-				
-				var newState: EditorPlaceholderState = .inactive
-				
-				if isEditorPlaceholderSelected(selectedRange: selectedRange, tokenRange: range) {
-					newState = .active
-				}
-				
-				if newState != state {					
-					rangesToUpdate.append((range, newState))
-				}
-				
-			}
-		
-		}
-		
-		var didBeginEditing = false
-		
-		if !rangesToUpdate.isEmpty {
-			textStorage.beginEditing()
-			didBeginEditing = true
-		}
-		
-		for (range, state) in rangesToUpdate {
-			
-			var attr = [NSAttributedString.Key: Any]()
-			attr[.editorPlaceholder] = state
-
-			textStorage.addAttributes(attr, range: range)
-
-		}
-		
-		if didBeginEditing {
-			textStorage.endEditing()
-		}
-
-	}
-	
-	func createAttributes(theme: SyntaxColorTheme, themeInfo: ThemeInfo, textStorage: NSTextStorage, cachedTokens: [CachedToken], source: String) {
-		
-		textStorage.beginEditing()
-
-		var attributes = [NSAttributedString.Key: Any]()
-		
-		let paragraphStyle = NSMutableParagraphStyle()
-		paragraphStyle.paragraphSpacing = 2.0
-		paragraphStyle.defaultTabInterval = themeInfo.spaceWidth * 4
-		paragraphStyle.tabStops = []
-		
-		let wholeRange = NSRange(location: 0, length: (source as NSString).length)
-		
-		attributes[.paragraphStyle] = paragraphStyle
-		
-		for (attr, value) in theme.globalAttributes() {
-			
-			attributes[attr] = value
-
-		}
-		
-		textStorage.setAttributes(attributes, range: wholeRange)
-		
-		let selectedRange = textView.selectedRange
-		
-		for cachedToken in cachedTokens {
-			
-			let token = cachedToken.token
-			
-			if token.isPlain {
-				continue
-			}
+    
+    func updateAttributes(textStorage: NSTextStorage, cachedTokens: [CachedToken], source: String) {
+        let selectedRange = textView.selectedRange
+        let fullRange = NSRange(location: 0, length: (source as NSString).length)
+        var rangesToUpdate = [(NSRange, EditorPlaceholderState)]()
+        
+        textStorage.enumerateAttribute(.editorPlaceholder, in: fullRange, options: []) { (value, range, stop) in
+            if let state = value as? EditorPlaceholderState {
+                var newState: EditorPlaceholderState = .inactive
+                
+                if isEditorPlaceholderSelected(selectedRange: selectedRange, tokenRange: range) {
+                    newState = .active
+                }
+                
+                if newState != state {
+                    rangesToUpdate.append((range, newState))
+                }
+            }
+        }
+        
+        var didBeginEditing = false
+        
+        if !rangesToUpdate.isEmpty {
+            textStorage.beginEditing()
+            didBeginEditing = true
+        }
+        
+        for (range, state) in rangesToUpdate {
+            var attr = [NSAttributedString.Key: Any]()
+            attr[.editorPlaceholder] = state
+            textStorage.addAttributes(attr, range: range)
+        }
+        
+        if didBeginEditing {
+            textStorage.endEditing()
+        }
+    }
+    
+    func createAttributes(theme: SyntaxColorTheme, themeInfo: ThemeInfo, textStorage: NSTextStorage, cachedTokens: [CachedToken], source: String) {
+        textStorage.beginEditing()
+        
+        var attributes = [NSAttributedString.Key: Any]()
+        
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.paragraphSpacing = 2.0
+        paragraphStyle.defaultTabInterval = themeInfo.spaceWidth * 4
+        paragraphStyle.tabStops = []
+        
+        let wholeRange = NSRange(location: 0, length: (source as NSString).length)
+        
+        attributes[.paragraphStyle] = paragraphStyle
+        
+        for (attr, value) in theme.globalAttributes() {
+            attributes[attr] = value
+        }
+        
+        textStorage.setAttributes(attributes, range: wholeRange)
+        
+        let selectedRange = textView.selectedRange
+        
+        for cachedToken in cachedTokens {
+            let token = cachedToken.token
+            guard token.isPlain == false else { continue }
+            guard token.isActive else { continue }
             
-            guard token.isActive else {
+            let range = cachedToken.nsRange
+            
+            if token.isEditorPlaceholder {
+                let startRange = NSRange(location: range.lowerBound, length: 2)
+                let endRange = NSRange(location: range.upperBound - 2, length: 2)
+                
+                let contentRange = NSRange(location: range.lowerBound + 2, length: range.length - 4)
+                
+                var attr = [NSAttributedString.Key: Any]()
+                
+                var state: EditorPlaceholderState = .inactive
+                
+                if isEditorPlaceholderSelected(selectedRange: selectedRange, tokenRange: range) {
+                    state = .active
+                }
+                
+                attr[.editorPlaceholder] = state
+                
+                textStorage.addAttributes(theme.attributes(for: token), range: contentRange)
+                
+                textStorage.addAttributes([.foregroundColor: Color.clear, .font: Font.systemFont(ofSize: 0.01)], range: startRange)
+                textStorage.addAttributes([.foregroundColor: Color.clear, .font: Font.systemFont(ofSize: 0.01)], range: endRange)
+                
+                textStorage.addAttributes(attr, range: range)
                 continue
             }
-			
-			let range = cachedToken.nsRange
-
-			if token.isEditorPlaceholder {
-				
-				let startRange = NSRange(location: range.lowerBound, length: 2)
-				let endRange = NSRange(location: range.upperBound - 2, length: 2)
-				
-				let contentRange = NSRange(location: range.lowerBound + 2, length: range.length - 4)
-				
-				var attr = [NSAttributedString.Key: Any]()
-				
-				var state: EditorPlaceholderState = .inactive
-				
-				if isEditorPlaceholderSelected(selectedRange: selectedRange, tokenRange: range) {
-					state = .active
-				}
-				
-				attr[.editorPlaceholder] = state
-				
-				textStorage.addAttributes(theme.attributes(for: token), range: contentRange)
-				
-				textStorage.addAttributes([.foregroundColor: Color.clear, .font: Font.systemFont(ofSize: 0.01)], range: startRange)
-				textStorage.addAttributes([.foregroundColor: Color.clear, .font: Font.systemFont(ofSize: 0.01)], range: endRange)
-				
-				textStorage.addAttributes(attr, range: range)
-				continue
-			}
-			
-			textStorage.addAttributes(theme.attributes(for: token), range: range)
-		}
+            
+            textStorage.addAttributes(theme.attributes(for: token), range: range)
+        }
         
         // Taken from brunophilipe/savannakit
         // Cleanup attributes. Good practice after applying many attributes at once.
         textStorage.fixAttributes(in: wholeRange)
-		
-		textStorage.endEditing()
-		
-	}
+        
+        textStorage.endEditing()
+    }
     
     public func highlight(line: Int, column: Int = 0, color: NSColor, message: String? = nil) {
-    
         DispatchQueue.main.sync {
-        
             guard let text = self.contentTextView.textStorage?.string as NSString? else { return assertionFailure() }
             
             var lineIndex = 1


### PR DESCRIPTION
Tried to run the project locally on macOS Sonoma (14.0) and noticed that the text content of the scroll view is entirely cut off because the `NSRulerView` takes the entire width of its parent (also the scroll view). As a result, the text content is entirely invisible and the ruler fills the view.

To resolve this, I've taken the `rect` parameter provided to `drawHashMarksAndLabels` in [LineRulerView.swift](https://github.com/IvanMathy/savannakit/compare/feat/multilineEditing...Sam-Spencer:savannakit:feat/multilineEditing#diff-6a6474445aff84b95372b00fe1b091d0243e25b6a4eb36db05b4d93c5ea17dfc) and updated its width value based on available information.

### Preview

**Before**:
<img width="793" alt="Screenshot 2023-11-02 at 12 46 59 PM" src="https://github.com/IvanMathy/savannakit/assets/2374407/3717eef0-8dba-4056-ac7a-5585290a35ef">

**After**:
<img width="793" alt="Screenshot 2023-11-02 at 12 47 47 PM" src="https://github.com/IvanMathy/savannakit/assets/2374407/4b87dbf5-911a-432a-96cc-e617a4ec2a3e">
